### PR TITLE
cranker: Use hostname and region in solana_metrics host_id & instructions markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 cranker/.env
 .DS_Store
 **/.DS_Store
+credentials/

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,5 @@
 services:
-  cranker:
+  interceptor-cranker:
     build:
       dockerfile: ./cranker.Dockerfile
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,5 +9,7 @@ services:
       - PROGRAM_ID=${PROGRAM_ID:-5TAiuAh3YGDbwjEruC1ZpXTJWdNDS7Ur7VeqNNiHMmGV}
       - INTERVAL_SECONDS=${INTERVAL_SECONDS:-60}
       - SOLANA_METRICS_CONFIG=${SOLANA_METRICS_CONFIG}
+      - CLUSTER=${CLUSTER}
+      - REGION=${REGION:-local}
     volumes:
       - ./credentials:/var/secrets

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,6 @@ services:
       - INTERVAL_SECONDS=${INTERVAL_SECONDS:-60}
       - SOLANA_METRICS_CONFIG=${SOLANA_METRICS_CONFIG}
       - CLUSTER=${CLUSTER}
-      - REGION=${REGION:-local}
+      - REGION=${REGION}
     volumes:
       - ./credentials:/var/secrets

--- a/cranker-bot-quick-start.md
+++ b/cranker-bot-quick-start.md
@@ -64,33 +64,19 @@ Once the setup is complete use the following commands to run/manage the docker c
 ### Start Docker
 
 ```bash
-docker compose --env-file .env up -d --build  stakenet-keeper --remove-orphans
+docker compose --env-file .env up -d --build  interceptor-cranker --remove-orphans
 ```
 
 ### View Logs
 
 ```bash
-docker logs stakenet-keeper -f
+docker logs interceptor-cranker -f
 ```
 
 ### Stop Docker\*\*
 
 ```bash
-docker stop stakenet-keeper; docker rm stakenet-keeper;
-```
-
-## Run from Dockerhub
-
-This image is available on Dockerhub at: https://hub.docker.com/r/jitolabs/stakenet-keeper
-
-```bash
-docker pull jitolabs/stakenet-keeper:latest
-docker run -d \
-  --name stakenet-keeper \
-  --env-file .env \
-  -v $(pwd)/credentials:/credentials \
-  --restart on-failure:5 \
-  jitolabs/stakenet-keeper:latest
+docker stop interceptor-cranker; docker rm stakenet-keeper;
 ```
 
 ## Running as Binary
@@ -100,18 +86,19 @@ To run the keeper in terminal, build for release and run the program.
 ### Build for Release
 
 ```bash
-cargo build --release --bin stakenet-keeper
+cd cranker
+cargo build --release
 ```
 
 ### Run Keeper
 
 ```bash
-RUST_LOG=info ./target/release/stakenet-keeper
+RUST_LOG=info ./target/release/stake-deposit-interceptor-cranker
 ```
 
 To see all available parameters run:
 
 ```bash
-RUST_LOG=info ./target/release/stakenet-keeper -h
+RUST_LOG=info ./target/release/stake-deposit-interceptor-cranker -h
 ```
 

--- a/cranker-bot-quick-start.md
+++ b/cranker-bot-quick-start.md
@@ -15,9 +15,10 @@ solana-keygen new -o ./credentials/keypair.json
 
 ### ENV
 
-In the root directory create `.env` file
+In the cranker directory create `.env` file
 
 ```bash
+cd cranker
 touch .env
 ```
 
@@ -40,7 +41,7 @@ REGION=local
 RUST_LOG="info,solana_gossip=error,solana_metrics=info"
 
 # Path to keypair used to execute tranasactions
-KEYPAIR_PATH=./credentials/keypair.json
+KEYPAIR_PATH=../credentials/keypair.json
 
 # Program ID (Pubkey as base58 string)
 PROGRAM_ID=5TAiuAh3YGDbwjEruC1ZpXTJWdNDS7Ur7VeqNNiHMmGV
@@ -76,7 +77,7 @@ docker logs interceptor-cranker -f
 ### Stop Docker\*\*
 
 ```bash
-docker stop interceptor-cranker; docker rm stakenet-keeper;
+docker stop interceptor-cranker; docker rm interceptor-cranker;
 ```
 
 ## Running as Binary

--- a/cranker-bot-quick-start.md
+++ b/cranker-bot-quick-start.md
@@ -1,0 +1,117 @@
+# Cranker Bot Quick-start
+
+Below are the steps to configuring and running the Stake Deposit Interceptor Bot. We recommend running it as a docker container.
+
+## Setup
+
+### Credentials
+
+In the root directory create a new folder named `credentials` and then populate it with a keypair. This is keypair that signs and pays for all transactions.
+
+```bash
+mkdir credentials
+solana-keygen new -o ./credentials/keypair.json
+```
+
+### ENV
+
+In the root directory create `.env` file
+
+```bash
+touch .env
+```
+
+Then copy file contents below into the cranker sub-directory dotenv file at `./cranker/.env`. Everything should be set as-is, however you will need to include an `RPC_URL` and `WS_URL` that can handle getProgramAccounts calls.
+
+```bash
+# RPC URL for the cluster
+RPC_URL="YOUR RPC URL"
+
+# Websocket URL for the cluster
+WS_URL="YOUR RPC WS URL"
+
+# Cluster to specify (mainnet, testnet, devnet)
+CLUSTER=mainnet
+
+# Region to specify for metrics purposes (us-east, eu-west, local, etc.)
+REGION=local
+
+# Log levels
+RUST_LOG="info,solana_gossip=error,solana_metrics=info"
+
+# Path to keypair used to execute tranasactions
+KEYPAIR_PATH=./credentials/keypair.json
+
+# Program ID (Pubkey as base58 string)
+PROGRAM_ID=5TAiuAh3YGDbwjEruC1ZpXTJWdNDS7Ur7VeqNNiHMmGV
+
+# Interval in seconds to check for cranking conditions
+INTERVAL_SECONDS=60
+
+# Log levels
+RUST_LOG="info,solana_gossip=error,solana_metrics=info"
+
+# Metrics upload influx server (optional)
+SOLANA_METRICS_CONFIG=""
+```
+
+## Running Docker image from source
+
+Once the setup is complete use the following commands to run/manage the docker container:
+
+> Note: We are running `Docker version 24.0.5, build ced0996`
+
+### Start Docker
+
+```bash
+docker compose --env-file .env up -d --build  stakenet-keeper --remove-orphans
+```
+
+### View Logs
+
+```bash
+docker logs stakenet-keeper -f
+```
+
+### Stop Docker\*\*
+
+```bash
+docker stop stakenet-keeper; docker rm stakenet-keeper;
+```
+
+## Run from Dockerhub
+
+This image is available on Dockerhub at: https://hub.docker.com/r/jitolabs/stakenet-keeper
+
+```bash
+docker pull jitolabs/stakenet-keeper:latest
+docker run -d \
+  --name stakenet-keeper \
+  --env-file .env \
+  -v $(pwd)/credentials:/credentials \
+  --restart on-failure:5 \
+  jitolabs/stakenet-keeper:latest
+```
+
+## Running as Binary
+
+To run the keeper in terminal, build for release and run the program.
+
+### Build for Release
+
+```bash
+cargo build --release --bin stakenet-keeper
+```
+
+### Run Keeper
+
+```bash
+RUST_LOG=info ./target/release/stakenet-keeper
+```
+
+To see all available parameters run:
+
+```bash
+RUST_LOG=info ./target/release/stakenet-keeper -h
+```
+

--- a/cranker/src/lib.rs
+++ b/cranker/src/lib.rs
@@ -38,6 +38,8 @@ pub struct CrankerConfig {
     pub payer: Arc<Keypair>, // Wrapped in Arc
     pub interval: Duration,
     pub commitment: CommitmentConfig,
+    pub cluster: String,
+    pub region: String,
 }
 
 pub struct InterceptorCranker {


### PR DESCRIPTION
**Problem**
We would like to add replicas of stake deposit interceptor for redundancy purposes but lack the ability to differentiate between instances that are emitting metrics.

**Solution**
- Use hostname as a component of the solana metrics host_id
- Use region as a component of the solana metrics host_id
- Pass cluster and region in the docker compose file
- Add cranker-quick-start.md for cranker ops documentation

```
     Running `target/debug/stake-deposit-interceptor-cranker`
  2025-04-08T00:35:37.646718Z  INFO stake_deposit_interceptor_cranker: Logger initialized
    at src/main.rs:74 on ThreadId(1)

  2025-04-08T00:35:37.646974Z  INFO stake_deposit_interceptor_cranker: Environment loaded
    at src/main.rs:78 on ThreadId(1)

  2025-04-08T00:35:37.647632Z  INFO stake_deposit_interceptor_cranker: Configuration loaded successfully:
    at src/main.rs:83 on ThreadId(1)

  2025-04-08T00:35:37.647637Z  INFO stake_deposit_interceptor_cranker: RPC URL: YOUR RPC URL
    at src/main.rs:84 on ThreadId(1)

  2025-04-08T00:35:37.647642Z  INFO stake_deposit_interceptor_cranker: WS URL: YOUR RPC WS URL
    at src/main.rs:85 on ThreadId(1)

  2025-04-08T00:35:37.647657Z  INFO stake_deposit_interceptor_cranker: Program ID: 5TAiuAh3YGDbwjEruC1ZpXTJWdNDS7Ur7VeqNNiHMmGV
    at src/main.rs:86 on ThreadId(1)

  2025-04-08T00:35:37.647688Z  INFO stake_deposit_interceptor_cranker: Payer: APgSnw3nADGVm7e5Nc4EaaDBDjMpjFf1WndYecxuJVee
    at src/main.rs:87 on ThreadId(1)

  2025-04-08T00:35:37.647698Z  INFO stake_deposit_interceptor_cranker: Interval: 60s
    at src/main.rs:88 on ThreadId(1)

  2025-04-08T00:35:37.647701Z  INFO stake_deposit_interceptor_cranker: Cluster: mainnet
    at src/main.rs:89 on ThreadId(1)

  2025-04-08T00:35:37.647703Z  INFO stake_deposit_interceptor_cranker: Region: local
    at src/main.rs:90 on ThreadId(1)

  2025-04-08T00:35:37.649721Z  INFO solana_metrics::metrics: host id: interceptor-cranker_local_mainnet_Erics-MBP.MG8702
```