### PR TITLE
cranker: Cluster tag in emitted metrics

### DIFF
--- a/cranker/src/main.rs
+++ b/cranker/src/main.rs
@@ -1,14 +1,14 @@
 use ::{
-    stake_deposit_interceptor_cranker::{ InterceptorCranker, CrankerConfig },
+    dotenv::dotenv,
     solana_metrics::set_host_id,
     solana_sdk::{
-        signature::{ read_keypair_file, Signer }, // Added Signer trait
-        pubkey::Pubkey,
         commitment_config::CommitmentConfig,
+        pubkey::Pubkey,
+        signature::{read_keypair_file, Signer}, // Added Signer trait
     },
-    std::{ str::FromStr, time::Duration, process::Command, sync::Arc },
-    dotenv::dotenv,
-    tracing::{ info, Level },
+    stake_deposit_interceptor_cranker::{CrankerConfig, InterceptorCranker},
+    std::{process::Command, str::FromStr, sync::Arc, time::Duration},
+    tracing::{info, Level},
 };
 
 fn load_config() -> Result<CrankerConfig, Box<dyn std::error::Error>> {
@@ -19,34 +19,30 @@ fn load_config() -> Result<CrankerConfig, Box<dyn std::error::Error>> {
 
     let ws_url = std::env::var("WS_URL").map_err(|_| "WS_URL not found in environment")?;
 
-    let keypair_path = std::env
-        ::var("KEYPAIR_PATH")
-        .map_err(|_| "KEYPAIR_PATH not found in environment")?;
+    let keypair_path =
+        std::env::var("KEYPAIR_PATH").map_err(|_| "KEYPAIR_PATH not found in environment")?;
 
     let payer = Arc::new(
-        read_keypair_file(&keypair_path).map_err(|_|
-            format!("Failed to read keypair from {}", keypair_path)
-        )?
+        read_keypair_file(&keypair_path)
+            .map_err(|_| format!("Failed to read keypair from {}", keypair_path))?,
     );
 
     let program_id = Pubkey::from_str(
-        &std::env::var("PROGRAM_ID").map_err(|_| "PROGRAM_ID not found in environment")?
-    ).map_err(|_| "Invalid PROGRAM_ID format")?;
+        &std::env::var("PROGRAM_ID").map_err(|_| "PROGRAM_ID not found in environment")?,
+    )
+    .map_err(|_| "Invalid PROGRAM_ID format")?;
 
     let interval = Duration::from_secs(
-        std::env
-            ::var("INTERVAL_SECONDS")
+        std::env::var("INTERVAL_SECONDS")
             .map_err(|_| "INTERVAL_SECONDS not found in environment")?
             .parse()
-            .map_err(|_| "INTERVAL_SECONDS must be a valid number")?
+            .map_err(|_| "INTERVAL_SECONDS must be a valid number")?,
     );
 
-    let cluster = std::env::var("CLUSTER")
-        .map_err(|_| "CLUSTER not found in environment")?;
+    let cluster = std::env::var("CLUSTER").map_err(|_| "CLUSTER not found in environment")?;
 
-    let region = std::env::var("REGION")
-        .map_err(|_| "REGION not found in environment")?;
- 
+    let region = std::env::var("REGION").map_err(|_| "REGION not found in environment")?;
+
     Ok(CrankerConfig {
         rpc_url,
         ws_url,
@@ -62,8 +58,7 @@ fn load_config() -> Result<CrankerConfig, Box<dyn std::error::Error>> {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize logging with a simpler configuration
-    tracing_subscriber
-        ::fmt() // Use fully qualified path
+    tracing_subscriber::fmt() // Use fully qualified path
         .with_max_level(Level::INFO)
         .with_file(true)
         .with_line_number(true)

--- a/cranker/src/metrics.rs
+++ b/cranker/src/metrics.rs
@@ -9,7 +9,7 @@ use crate::CrankerError;
 
 pub fn emit_error(message: String, cluster_name: &str) {
     error!(message);
-    datapoint_info!("sdi-error", ("message", message, String),);
+    datapoint_info!("sdi-error", ("message", message, String), "cluster" => cluster_name);
 }
 
 pub async fn emit_heartbeat(

--- a/cranker/src/metrics.rs
+++ b/cranker/src/metrics.rs
@@ -7,12 +7,16 @@ use tracing::error;
 
 use crate::CrankerError;
 
-pub fn emit_error(message: String) {
+pub fn emit_error(message: String, cluster_name: &str) {
     error!(message);
     datapoint_info!("sdi-error", ("message", message, String),);
 }
 
-pub async fn emit_heartbeat(rpc_client: Arc<RpcClient>, tick: u64) -> Result<(), CrankerError> {
+pub async fn emit_heartbeat(
+    rpc_client: Arc<RpcClient>,
+    tick: u64,
+    cluster_name: &str,
+) -> Result<(), CrankerError> {
     let current_slot = rpc_client.get_slot().await?;
     let current_epoch = rpc_client.get_epoch_info().await?.epoch;
     let epoch_percentage =
@@ -24,6 +28,7 @@ pub async fn emit_heartbeat(rpc_client: Arc<RpcClient>, tick: u64) -> Result<(),
         ("current-epoch", current_epoch, i64),
         ("current-slot", current_slot, i64),
         ("epoch-percentage", epoch_percentage, f64),
+        "cluster" => cluster_name,
     );
 
     Ok(())
@@ -34,6 +39,7 @@ pub fn emit_crank(
     future_deposits: u64,
     not_yet_expired_receipts: u64,
     claimed_receipts: u64,
+    cluster_name: &str,
 ) {
     datapoint_info!(
         "sdi-crank",
@@ -41,10 +47,11 @@ pub fn emit_crank(
         ("future-deposits", future_deposits, i64),
         ("not-yet-expired-receipts", not_yet_expired_receipts, i64),
         ("claimed-receipts", claimed_receipts, i64),
+        "cluster" => cluster_name,
     );
 }
 
-pub fn emit_deposit_receipt(deposit_receipt: &DepositReceipt) {
+pub fn emit_deposit_receipt(deposit_receipt: &DepositReceipt, cluster_name: &str) {
     let base = deposit_receipt.base.to_string();
     let cool_down_seconds: u64 = deposit_receipt.cool_down_seconds.into();
     let deposit_time: u64 = deposit_receipt.deposit_time.into();
@@ -72,5 +79,6 @@ pub fn emit_deposit_receipt(deposit_receipt: &DepositReceipt) {
             String
         ),
         ("account-string", account_string, String),
+        "cluster" => cluster_name,
     );
 }


### PR DESCRIPTION
**Problem**
We would like to differentiate between metrics and alerts emitted from the perspectives of different Solana clusters yet lack the ability to do so.

**Solution**
- Add `cluster` tag to all emitted metrics and errors