### PR TITLE
CI/CD: Change to `big-runner-1`

### DIFF
--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-container:
-    runs-on: ubuntu-latest
+    runs-on: big-runner-1
     
     steps:
     - name: Checkout repository


### PR DESCRIPTION
### Problem

- Took time to build and publish image of kobe

### Solution

- Changes the runner from `ubuntu-latest` to `big-runner-1` for the build-container job