### PR TITLE
L-02: Use safe casting

### DIFF
--- a/stake_deposit_interceptor/src/processor.rs
+++ b/stake_deposit_interceptor/src/processor.rs
@@ -775,12 +775,12 @@ impl Processor {
             let conversion_rate_bps = (stake_pool.total_lamports as u128)
                 .checked_mul(BASIS_POINTS_MAX as u128)
                 .and_then(|n| n.checked_div(stake_pool.pool_token_supply as u128))
-                .map(|n| n as u64)
+                .and_then(|n| u64::try_from(n).ok())
                 .ok_or(StakeDepositInterceptorError::ArithmeticError)?;
             (pool_tokens_fee as u128)
                 .checked_mul(conversion_rate_bps as u128)
                 .and_then(|n| n.checked_div(BASIS_POINTS_MAX as u128))
-                .map(|n| n as u64)
+                .and_then(|n| u64::try_from(n).ok())
                 .ok_or(StakeDepositInterceptorError::ArithmeticError)?
         };
 


### PR DESCRIPTION
#### Problem

- It’s best to use safe casting when converting from u128 to u64

#### Solution

- Consider replacing the unchecked `as u64` casts with checked conversions such as `u64::try_from(...)`